### PR TITLE
fix(grammar/eol): do not consume token

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -115,8 +115,6 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
     while (is_nbsp(lexer))
       skip(lexer);
     if (is_eol(lexer)) {
-      if (!lexer->eof(lexer))
-        advance(lexer);
       lexer->result_symbol = _EOL;
       return true;
     }


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI.
- [x] The script/parse-examples passes without issues.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
